### PR TITLE
FIX: Support for git submodule directories

### DIFF
--- a/dired-k.el
+++ b/dired-k.el
@@ -195,7 +195,7 @@
                  (kill-buffer proc-buf))))))))))
 
 (defsubst dired-k--root-directory ()
-  (locate-dominating-file default-directory ".git/"))
+  (locate-dominating-file default-directory ".git"))
 
 (defsubst dired-k--git-style-char (stat)
   (cl-case stat


### PR DESCRIPTION
The git submodule directory has a plain text .git file, not a directory.
And in that text file is the path to the actual gitdir.
So the argument to the local-dominated-file function is .git, without a slash.